### PR TITLE
Webpack output.path support

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ OctoWebpackPlugin.prototype.apply = function (compiler) {
         }    
         
         
-        for (var nameAndPath in compilation.assets) {
-            pkg.append(nameAndPath);
+        for (var name in compilation.assets) {            
+            pkg.append(name, compilation.assets[name].existsAt);
         }
 
         pkg.toFile("./", function (error, data) {


### PR DESCRIPTION
Octopack is unable to find output files if output.path is specified in webpack configuration. To fix this, We could pass asset's absolute path to archiver during packing.